### PR TITLE
Fixed "optiLoad.h not found" error.

### DIFF
--- a/optiLoader.h
+++ b/optiLoader.h
@@ -1,3 +1,6 @@
+#ifndef OPTILOADER_H
+#define OPTILOADER_H
+
 #include <stdint.h>
 
 typedef struct image {
@@ -23,3 +26,5 @@ typedef struct alias {
 
 // Forward decl
 extern const image_t PROGMEM image_328, image_328p, image_168, image_8;
+
+#endif

--- a/optiLoader.ino
+++ b/optiLoader.ino
@@ -82,7 +82,10 @@
 
 
 #include <avr/pgmspace.h>
+
+#ifndef OPTILOADER_H
 #include "optiLoader.h"
+#endif
 
 char Arduino_preprocessor_hint;
 


### PR DESCRIPTION
In newer versions of Arduino IDE (1.6.x and 1.8.3) optiLoader does not compile because the optiLoader.h  file is included too many times. This was corrected by using pre-compiler IF statements.